### PR TITLE
Disable persistent database connections for ASGI compatibility

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -83,7 +83,7 @@ DATABASES = {
     'default': dj_database_url.config(
         # TODO update this row to your proper connection string
         default='postgresql://postgres:postgres@localhost:5432/mysite',
-        conn_max_age=600
+        conn_max_age=0
     )
 }
 


### PR DESCRIPTION
## Summary
- Set `conn_max_age=0` in database configuration to disable persistent connections
- This change is recommended by Django documentation for ASGI applications

## Background
When using ASGI, persistent connections can cause issues with connection pool exhaustion and resource contention. Each long-lived ASGI connection could hold its own persistent database connection, quickly exhausting the database connection pool.